### PR TITLE
config(compose & chart): bump chart and frontend versions to 1.7.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 DOMAIN_NAME="r2devops.<domain_name>"
 CERTIFICATE_EMAIL="tech@r2devops.io"
 JOBS_GITLAB_URL="https://gitlab.com"
-FRONTEND_IMAGE_TAG="v1.4.3"
+FRONTEND_IMAGE_TAG="v1.7.1"
 BACKEND_IMAGE_TAG="v1.14.1"
 
 # OIDC

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ DOMAIN_NAME="r2devops.<domain_name>"
 CERTIFICATE_EMAIL="tech@r2devops.io"
 JOBS_GITLAB_URL="https://gitlab.com"
 FRONTEND_IMAGE_TAG="v1.7.2"
-BACKEND_IMAGE_TAG="v1.14.1"
+BACKEND_IMAGE_TAG="v1.14.2"
 
 # OIDC
 GITLAB_OIDC='

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 DOMAIN_NAME="r2devops.<domain_name>"
 CERTIFICATE_EMAIL="tech@r2devops.io"
 JOBS_GITLAB_URL="https://gitlab.com"
-FRONTEND_IMAGE_TAG="v1.7.1"
+FRONTEND_IMAGE_TAG="v1.7.2"
 BACKEND_IMAGE_TAG="v1.14.1"
 
 # OIDC

--- a/charts/r2devops/Chart.yaml
+++ b/charts/r2devops/Chart.yaml
@@ -3,7 +3,7 @@ name: r2devops
 description: Helm chart for R2Devops
 type: application
 version: 0.2.6
-appVersion: "1.14.1"
+appVersion: "1.14.2"
 dependencies:
   # ref. https://k8s.ory.sh/helm/kratos.html
   - name: kratos

--- a/charts/r2devops/Chart.yaml
+++ b/charts/r2devops/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: r2devops
 description: Helm chart for R2Devops
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: "1.14.1"
 dependencies:
   # ref. https://k8s.ory.sh/helm/kratos.html

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -3,7 +3,7 @@ front:
   type: frontend
   name: r2devops-front
   image: registry.gitlab.com/r2devops/frontend
-  tag: v1.4.3
+  tag: v1.7.1
   replicaCount: 1
   port: 3000
   livenessEndpoint: "/"

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -27,7 +27,7 @@ jobs:
   type: backend
   name: r2devops-jobs
   image: registry.gitlab.com/r2devops/jobs
-  tag: v1.14.1
+  tag: v1.14.2
   replicaCount: 1
   port: 3000
   livenessEndpoint: "/job/health/alive"
@@ -46,7 +46,7 @@ worker:
   type: backend
   name: r2devops-worker
   image: registry.gitlab.com/r2devops/jobs
-  tag: v1.14.1
+  tag: v1.14.2
   replicaCount: 5
   command: ["./app"]
   args: ["--worker"]

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -3,7 +3,7 @@ front:
   type: frontend
   name: r2devops-front
   image: registry.gitlab.com/r2devops/frontend
-  tag: v1.7.1
+  tag: v1.7.2
   replicaCount: 1
   port: 3000
   livenessEndpoint: "/"


### PR DESCRIPTION
This version adds dashboard timestamp selector, some sections documentation and fix the session check for protected routes