### PR TITLE
Various fixes to allow deploying with ArgoCD on AWS accounts

### DIFF
--- a/charts/r2devops/Chart.yaml
+++ b/charts/r2devops/Chart.yaml
@@ -4,17 +4,22 @@ description: Helm chart for R2Devops
 type: application
 version: "2.10.5"
 appVersion: "2.10.5"
-# dependencies:
-#   # ref. https://github.com/bitnami/charts/blob/main/bitnami/redis
-#   - name: redis
-#     version: 16.13.2  # appVersion: 6.2.7
-#     repository: https://charts.bitnami.com/bitnami
-#     condition: redis.dependency.enabled
-#   # ref. https://github.com/bitnami/charts/blob/main/bitnami/postgresql
-#   - name: postgresql
-#     version: 11.9.13  # appVersion: 14.5.0
-#     repository: https://charts.bitnami.com/bitnami
-#     condition: postgresql.dependency.enabled
+
+# If you don't want to use Redis and PostgreSQL from the chart, and you also
+# want to prevent Helm from making any HTTP requests to fetch dependencies,
+# comment out the entire `dependencies` section below.
+
+dependencies:
+  # ref. https://github.com/bitnami/charts/blob/main/bitnami/redis
+  - name: redis
+    version: 16.13.2  # appVersion: 6.2.7
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.dependency.enabled
+  # ref. https://github.com/bitnami/charts/blob/main/bitnami/postgresql
+  - name: postgresql
+    version: 11.9.13  # appVersion: 14.5.0
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.dependency.enabled
 maintainers:
   - name: devpro
     email: bertrand@devpro.fr

--- a/charts/r2devops/Chart.yaml
+++ b/charts/r2devops/Chart.yaml
@@ -4,17 +4,17 @@ description: Helm chart for R2Devops
 type: application
 version: "2.10.5"
 appVersion: "2.10.5"
-dependencies:
-  # ref. https://github.com/bitnami/charts/blob/main/bitnami/redis
-  - name: redis
-    version: 16.13.2  # appVersion: 6.2.7
-    repository: https://charts.bitnami.com/bitnami
-    condition: redis.dependency.enabled
-  # ref. https://github.com/bitnami/charts/blob/main/bitnami/postgresql
-  - name: postgresql
-    version: 11.9.13  # appVersion: 14.5.0
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.dependency.enabled
+# dependencies:
+#   # ref. https://github.com/bitnami/charts/blob/main/bitnami/redis
+#   - name: redis
+#     version: 16.13.2  # appVersion: 6.2.7
+#     repository: https://charts.bitnami.com/bitnami
+#     condition: redis.dependency.enabled
+#   # ref. https://github.com/bitnami/charts/blob/main/bitnami/postgresql
+#   - name: postgresql
+#     version: 11.9.13  # appVersion: 14.5.0
+#     repository: https://charts.bitnami.com/bitnami
+#     condition: postgresql.dependency.enabled
 maintainers:
   - name: devpro
     email: bertrand@devpro.fr

--- a/charts/r2devops/templates/configmap.yaml
+++ b/charts/r2devops/templates/configmap.yaml
@@ -2,10 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- range $key, $val := .Values.additionalAnnotations }}
+    {{- range $key, $val := . }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- end }}
   labels:
     app: {{ .Values.front.name }}
     app.kubernetes.io/name: {{ .Values.front.name }}

--- a/charts/r2devops/templates/configmap.yaml
+++ b/charts/r2devops/templates/configmap.yaml
@@ -31,14 +31,18 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- range $key, $val := .Values.additionalAnnotations }}
+    {{- range $key, $val := . }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- end }}
+  {{- with .Values.additionalLabels }}
   labels:
-    {{- range $key, $val := .Values.additionalLabels }}
+    {{- range $key, $val := . }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- end }}
   name: {{ .Values.customCertificateAuthority.configMapName }}
 data:
   {{- range .Values.customCertificateAuthority.certificates }}

--- a/charts/r2devops/templates/configmap.yaml
+++ b/charts/r2devops/templates/configmap.yaml
@@ -2,9 +2,16 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    {{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   labels:
     app: {{ .Values.front.name }}
     app.kubernetes.io/name: {{ .Values.front.name }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   name: {{ .Values.front.name }}
 data:
   config.body: |
@@ -22,9 +29,16 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    {{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  labels:
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   name: {{ .Values.customCertificateAuthority.configMapName }}
 data:
   {{- range .Values.customCertificateAuthority.certificates }}
   {{ .name }}: {{ .value | quote }}
   {{- end }}
-

--- a/charts/r2devops/templates/configmap.yaml
+++ b/charts/r2devops/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
       "gitLabApiUrl": "{{ .Values.gitlab.domain }}",
       "selfHosted": true,
       "docUrl": "https://docs.r2devops.io",
-      "debug": true,
+      "debug": false,
       "allowExternalQueries": true
     }
 

--- a/charts/r2devops/templates/configmap.yaml
+++ b/charts/r2devops/templates/configmap.yaml
@@ -16,12 +16,12 @@ metadata:
 data:
   config.body: |
     {
-      "appTitle": "R2Devops",
+      "appTitle": "R2Devops BAS",
       "apiUrl": "https://{{ .Values.jobs.host }}/api",
       "gitLabApiUrl": "{{ .Values.gitlab.domain }}",
       "selfHosted": true,
       "docUrl": "https://docs.r2devops.io",
-      "debug": false,
+      "debug": true,
       "allowExternalQueries": true
     }
 

--- a/charts/r2devops/templates/configmap.yaml
+++ b/charts/r2devops/templates/configmap.yaml
@@ -16,7 +16,7 @@ metadata:
 data:
   config.body: |
     {
-      "appTitle": "R2Devops BAS",
+      "appTitle": "R2Devops",
       "apiUrl": "https://{{ .Values.jobs.host }}/api",
       "gitLabApiUrl": "{{ .Values.gitlab.domain }}",
       "selfHosted": true,

--- a/charts/r2devops/templates/deployment.yaml
+++ b/charts/r2devops/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
         {{ $key }}: {{ $val | quote }}
         {{- end }}
     spec:
+      automountServiceAccountToken: {{ .automountServiceAccountToken }}
+
       containers:
         - name: {{ .name }}
           image: {{ .image }}:{{ .tag }}
@@ -167,6 +169,10 @@ spec:
             {{- end }}
           {{- end }}
 
+      {{- with .serviceAccountName }}
+      serviceAccountName: {{ . | quote }}
+      {{- end }}
+
       {{- with .podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -196,8 +202,6 @@ spec:
           name: {{ $.Values.postgresql.global.postgresql.auth.existingSecret }}
           {{- end }}
         {{- end }}
-      {{- with .serviceAccountName }}
-      serviceAccountName: {{ . | quote }}
-      {{- end }}
+
 {{- end }}
 {{ end }}

--- a/charts/r2devops/templates/deployment.yaml
+++ b/charts/r2devops/templates/deployment.yaml
@@ -145,6 +145,11 @@ spec:
 
             {{- end }}
 
+          {{- with .securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
           volumeMounts:
             - name: ca-certificates
               mountPath: /usr/local/share/ca-certificates/
@@ -161,6 +166,11 @@ spec:
               readOnly: true
             {{- end }}
           {{- end }}
+
+      {{- with .podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
       volumes:
         - name: ca-certificates

--- a/charts/r2devops/templates/deployment.yaml
+++ b/charts/r2devops/templates/deployment.yaml
@@ -18,6 +18,7 @@ metadata:
   name: {{ .name }}
 spec:
   replicas: {{ .replicaCount }}
+  revisionHistoryLimit: {{ .revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ .name }}

--- a/charts/r2devops/templates/deployment.yaml
+++ b/charts/r2devops/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
             - name: JOBS_REDIS_PORT
               value: "{{ $.Values.redis.custom.port }}"
             - name: JOBS_REDIS_DB
-              value: "0"
+              value: "{{ $.Values.redis.custom.databaseIndex }}"
             - name: JOBS_REDIS_USER
               value: "{{ $.Values.redis.custom.user }}"
             - name: JOBS_REDIS_SET_NAMESPACES_TTL

--- a/charts/r2devops/templates/deployment.yaml
+++ b/charts/r2devops/templates/deployment.yaml
@@ -169,12 +169,22 @@ spec:
             {{- end }}
           {{- end }}
 
+      {{- with .nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- with .serviceAccountName }}
       serviceAccountName: {{ . | quote }}
       {{- end }}
 
       {{- with .podSecurityContext }}
       securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .tolerations }}
+      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 

--- a/charts/r2devops/templates/deployment.yaml
+++ b/charts/r2devops/templates/deployment.yaml
@@ -169,6 +169,8 @@ spec:
           configMap:
             name: {{ .name }}
         {{- end }}
-
+      {{- with .serviceAccountName }}
+      serviceAccountName: {{ . | quote }}
+      {{- end }}
 {{- end }}
 {{ end }}

--- a/charts/r2devops/templates/deployment.yaml
+++ b/charts/r2devops/templates/deployment.yaml
@@ -154,6 +154,13 @@ spec:
               mountPath: /app/.next/server/app/config.body
               subPath: config.body
           {{- end }}
+          {{- if eq .type "backend" }}
+            {{- if and $.Values.postgresql.global.postgresql.auth.existingSecret (eq (default "" $.Values.postgresql.global.postgresql.auth.existingSecretType) "csi") }}
+            - mountPath: /mnt/{{ $.Values.postgresql.global.postgresql.auth.existingSecret }}
+              name: {{ $.Values.postgresql.global.postgresql.auth.existingSecret }}
+              readOnly: true
+            {{- end }}
+          {{- end }}
 
       volumes:
         - name: ca-certificates
@@ -168,6 +175,16 @@ spec:
         - name: config-volume
           configMap:
             name: {{ .name }}
+        {{- end }}
+        {{- if eq .type "backend" }}
+          {{- if and $.Values.postgresql.global.postgresql.auth.existingSecret (eq (default "" $.Values.postgresql.global.postgresql.auth.existingSecretType) "csi") }}
+        - csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ $.Values.postgresql.global.postgresql.auth.existingSecret }}
+          name: {{ $.Values.postgresql.global.postgresql.auth.existingSecret }}
+          {{- end }}
         {{- end }}
       {{- with .serviceAccountName }}
       serviceAccountName: {{ . | quote }}

--- a/charts/r2devops/templates/deployment.yaml
+++ b/charts/r2devops/templates/deployment.yaml
@@ -5,10 +5,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .name }}
+  annotations:
+    {{- range $key, $val := $.Values.additionalAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   labels:
     app: {{ .name }}
     app.kubernetes.io/name: {{ .name }}
+    {{- range $key, $val := $.Values.additionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  name: {{ .name }}
 spec:
   replicas: {{ .replicaCount }}
   selector:
@@ -20,6 +27,9 @@ spec:
       labels:
         app: {{ .name }}
         app.kubernetes.io/name: {{ .name }}
+        {{- range $key, $val := $.Values.additionalLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
     spec:
       containers:
         - name: {{ .name }}

--- a/charts/r2devops/templates/deployment.yaml
+++ b/charts/r2devops/templates/deployment.yaml
@@ -5,10 +5,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- with $.Values.additionalAnnotations }}
   annotations:
-    {{- range $key, $val := $.Values.additionalAnnotations }}
+    {{- range $key, $val := . }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- end }}
   labels:
     app: {{ .name }}
     app.kubernetes.io/name: {{ .name }}

--- a/charts/r2devops/templates/ingress.yaml
+++ b/charts/r2devops/templates/ingress.yaml
@@ -12,6 +12,11 @@ metadata:
     {{- range $key, $val := $.Values.additionalAnnotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+    {{- if .extraIngressAnnotations }}
+    {{- range $key, $val := .extraIngressAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- end }}
   labels:
     {{- range $key, $val := $.Values.additionalLabels }}
     {{ $key }}: {{ $val | quote }}

--- a/charts/r2devops/templates/ingress.yaml
+++ b/charts/r2devops/templates/ingress.yaml
@@ -5,11 +5,18 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .name }}
-  {{- with $.Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- range $key, $val := $.Values.ingress.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- range $key, $val := $.Values.additionalAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  labels:
+    {{- range $key, $val := $.Values.additionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  name: {{ .name }}
 spec:
   {{- if $.Values.ingress.className }}
   ingressClassName: {{ $.Values.ingress.className }}

--- a/charts/r2devops/templates/ingress.yaml
+++ b/charts/r2devops/templates/ingress.yaml
@@ -17,10 +17,12 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end }}
     {{- end }}
+  {{- with $.Values.additionalLabels }}
   labels:
-    {{- range $key, $val := $.Values.additionalLabels }}
+    {{- range $key, $val := . }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- end }}
   name: {{ .name }}
 spec:
   {{- if $.Values.ingress.className }}

--- a/charts/r2devops/templates/service.yaml
+++ b/charts/r2devops/templates/service.yaml
@@ -5,10 +5,12 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- with $.Values.additionalAnnotations }}
   annotations:
-    {{- range $key, $val := $.Values.additionalAnnotations }}
+    {{- range $key, $val := . }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- end }}
   labels:
     app: {{ .name }}
     app.kubernetes.io/name: {{ .name }}

--- a/charts/r2devops/templates/service.yaml
+++ b/charts/r2devops/templates/service.yaml
@@ -5,9 +5,16 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    {{- range $key, $val := $.Values.additionalAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   labels:
     app: {{ .name }}
     app.kubernetes.io/name: {{ .name }}
+    {{- range $key, $val := $.Values.additionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   name: {{ .name }}
 spec:
   type: ClusterIP

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -1,3 +1,9 @@
+# -- Additional annotations applied to all resources.
+additionalAnnotations: {}
+
+# -- Additional labels applied to all resources.
+additionalLabels: {}
+
 front:
   enabled: true
   type: frontend

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -27,6 +27,7 @@ front:
     # requests:
     #   cpu: 100m
     #   memory: 64Mi
+  extraIngressAnnotations: {}
 
 jobs:
   enabled: true
@@ -46,6 +47,7 @@ jobs:
   resources: {}
   # -- Optional existing service account name to use.
   serviceAccountName: ""
+  extraIngressAnnotations: {}
 
   # Not using secret for R2devops secrets (comment if you use secret)
   extraEnv:

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -164,6 +164,7 @@ redis:
     user: "default"
     port: 6379
     cert: ""
+    databaseIndex: 0
   replica:
     replicaCount: 0
 

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -150,6 +150,7 @@ postgresql:
       # auth:
       #   username: r2devops
       #   existingSecret: "postgresql-secret"
+      #   existingSecretType: "csi" # Remove or leave empty if secret is not managed by CSI Driver
       #   secretKeys:
       #     adminPasswordKey: "password"
       #     userPasswordKey: "password"

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -32,6 +32,7 @@ front:
   securityContext: {}
   # -- Optional security context for pods.
   podSecurityContext: {}
+  automountServiceAccountToken: true
 
 jobs:
   enabled: true
@@ -56,6 +57,7 @@ jobs:
   securityContext: {}
   # -- Optional security context for pods.
   podSecurityContext: {}
+  automountServiceAccountToken: true
 
   # Not using secret for R2devops secrets (comment if you use secret)
   extraEnv:
@@ -118,6 +120,7 @@ worker:
   securityContext: {}
   # -- Optional security context for pods.
   podSecurityContext: {}
+  automountServiceAccountToken: true
 
 ingress:
   enabled: false

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -34,6 +34,15 @@ front:
   podSecurityContext: {}
   automountServiceAccountToken: true
 
+  # NodeSelector is a selector which must be true for the pod to fit on a node.
+  # Selector which must match a node's labels for the pod to be scheduled on that node.
+  # For more info see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}
+
+  # Optional pod node tolerations.
+  # For more info see https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
+
 jobs:
   enabled: true
   type: backend
@@ -58,6 +67,15 @@ jobs:
   # -- Optional security context for pods.
   podSecurityContext: {}
   automountServiceAccountToken: true
+
+  # NodeSelector is a selector which must be true for the pod to fit on a node.
+  # Selector which must match a node's labels for the pod to be scheduled on that node.
+  # For more info see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}
+
+  # Optional pod node tolerations.
+  # For more info see https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
 
   # Not using secret for R2devops secrets (comment if you use secret)
   extraEnv:
@@ -121,6 +139,15 @@ worker:
   # -- Optional security context for pods.
   podSecurityContext: {}
   automountServiceAccountToken: true
+
+  # NodeSelector is a selector which must be true for the pod to fit on a node.
+  # Selector which must match a node's labels for the pod to be scheduled on that node.
+  # For more info see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}
+
+  # Optional pod node tolerations.
+  # For more info see https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
 
 ingress:
   enabled: false

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -11,6 +11,7 @@ front:
   image: docker.io/r2devopsio/frontend
   tag: v2.12.9
   replicaCount: 1
+  revisionHistoryLimit: 5
   port: 3000
   livenessEndpoint: "/"
   readinesspoint: "/"
@@ -50,6 +51,7 @@ jobs:
   image: docker.io/r2devopsio/jobs
   tag: v2.13.2
   replicaCount: 1
+  revisionHistoryLimit: 5
   port: 3000
   livenessEndpoint: "/api/health/alive"
   readinesspoint: "/api/health/ready"
@@ -122,6 +124,7 @@ worker:
   image: docker.io/r2devopsio/jobs
   tag: v2.13.2
   replicaCount: 20
+  revisionHistoryLimit: 5
   args:
     - "./app"
     - "--worker"

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -28,6 +28,10 @@ front:
     #   cpu: 100m
     #   memory: 64Mi
   extraIngressAnnotations: {}
+  # -- Optional security context for containers.
+  securityContext: {}
+  # -- Optional security context for pods.
+  podSecurityContext: {}
 
 jobs:
   enabled: true
@@ -48,6 +52,10 @@ jobs:
   # -- Optional existing service account name to use.
   serviceAccountName: ""
   extraIngressAnnotations: {}
+  # -- Optional security context for containers.
+  securityContext: {}
+  # -- Optional security context for pods.
+  podSecurityContext: {}
 
   # Not using secret for R2devops secrets (comment if you use secret)
   extraEnv:
@@ -106,6 +114,10 @@ worker:
   resources: {}
   # -- Optional existing service account name to use.
   serviceAccountName: ""
+  # -- Optional security context for containers.
+  securityContext: {}
+  # -- Optional security context for pods.
+  podSecurityContext: {}
 
 ingress:
   enabled: false

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -137,11 +137,11 @@ worker:
   resources: {}
   # -- Optional existing service account name to use.
   serviceAccountName: ""
+  automountServiceAccountToken: true
   # -- Optional security context for containers.
   securityContext: {}
   # -- Optional security context for pods.
   podSecurityContext: {}
-  automountServiceAccountToken: true
 
   # NodeSelector is a selector which must be true for the pod to fit on a node.
   # Selector which must match a node's labels for the pod to be scheduled on that node.

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -44,6 +44,8 @@ jobs:
   # Duration of users' session
   sessionTTL: "168h"
   resources: {}
+  # -- Optional existing service account name to use.
+  serviceAccountName: ""
 
   # Not using secret for R2devops secrets (comment if you use secret)
   extraEnv:
@@ -100,6 +102,8 @@ worker:
   host: ""
   tls: {}
   resources: {}
+  # -- Optional existing service account name to use.
+  serviceAccountName: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION
* Feat/Allow customizing revision history limits
  - For readability purpose in ArgoCD UI
* Feat/Allow customizing node selector and tolerations
  - Required when using Kubernetes clusters with various worker node types
* Feat/Allow customizing automount of service account
  - Required to follow Pods Security Standards
* Feat/Allow customizing security context
  - Required to follow Pods Security Standards
* Feat/Allow specifying additional annotations on ingresses
  - Required to expose service using alb-controller
* Feat/Allow customizing Redis database index
  - Useful when using a shared Redis instance
* Feat/Enable debug
  - Not working but it would be great to allow changing the log verbosity in case of problems 
* Feat/Allow using a secret managed by Secret CSI driver
  - To allow retrieving ASM Secrets with SecretCSIDriver  
* Feat/Allow specifying a service account for Jobs an Workers
  - To allow retrieving ASM Secrets with SecretCSIDriver by configuring IRSA on the service account
* Feat/Allow specifying additional labels and annotations
  - Useful when using ArgoCD Sync Waves
* Fix/Disable chart dependencies
  - Allow using ArgoCD to deploy the Kubernetes resources which always try to download the dependent charts even if usage conditions are not met 