### PR TITLE
conf(chart): enforce securityContext config for containers

### DIFF
--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -32,8 +32,24 @@ front:
     #   cpu: 100m
     #   memory: 64Mi
   extraIngressAnnotations: {}
-  # -- Optional security context for containers.
-  securityContext: {}
+  # -- Security context for front containers.
+  securityContext:
+    # -- Allow privilege escalation within the container.
+    allowPrivilegeEscalation: false
+    capabilities:
+      # -- Drop specified Linux capabilities.
+      drop: [ALL]
+    # -- Run the container in privileged mode.
+    privileged: false
+    # -- Enforce running the container as non-root. Leave `false` until the image is able to be run in rootless mode.
+    runAsNonRoot: false
+    # -- Run the container as the specified user id (uid). Leave `0` until the image is able to be run in rootless mode.
+    runAsUser: 0
+    # -- Run the container as the specified group id (gid). Leave `0` until the image is able to be run in rootless mode.
+    runAsGroup: 0
+    seccompProfile:
+      # -- The Seccomp profile to apply to this container.
+      type: RuntimeDefault
   # -- Optional security context for pods.
   podSecurityContext: {}
   automountServiceAccountToken: true
@@ -67,8 +83,24 @@ jobs:
   # -- Optional existing service account name to use.
   serviceAccountName: ""
   extraIngressAnnotations: {}
-  # -- Optional security context for containers.
-  securityContext: {}
+  # -- Security context for backend containers.
+  securityContext:
+    # -- Allow privilege escalation within the container.
+    allowPrivilegeEscalation: false
+    capabilities:
+      # -- Drop specified Linux capabilities.
+      drop: [ALL]
+    # -- Run the container in privileged mode.
+    privileged: false
+    # -- Enforce running the container as non-root. Leave `false` until the image is able to be run in rootless mode.
+    runAsNonRoot: false
+    # -- Run the container as the specified user id (uid). Leave `0` until the image is able to be run in rootless mode.
+    runAsUser: 0
+    # -- Run the container as the specified group id (gid). Leave `0` until the image is able to be run in rootless mode.
+    runAsGroup: 0
+    seccompProfile:
+      # -- The Seccomp profile to apply to this container.
+      type: RuntimeDefault
   # -- Optional security context for pods.
   podSecurityContext: {}
   automountServiceAccountToken: true
@@ -134,8 +166,24 @@ worker:
   # -- Optional existing service account name to use.
   serviceAccountName: ""
   automountServiceAccountToken: true
-  # -- Optional security context for containers.
-  securityContext: {}
+  # -- Security context for worker containers.
+  securityContext:
+    # -- Allow privilege escalation within the container.
+    allowPrivilegeEscalation: false
+    capabilities:
+      # -- Drop specified Linux capabilities.
+      drop: [ALL]
+    # -- Run the container in privileged mode.
+    privileged: false
+    # -- Enforce running the container as non-root. Leave `false` until the image is able to be run in rootless mode.
+    runAsNonRoot: false
+    # -- Run the container as the specified user id (uid). Leave `0` until the image is able to be run in rootless mode.
+    runAsUser: 0
+    # -- Run the container as the specified group id (gid). Leave `0` until the image is able to be run in rootless mode.
+    runAsGroup: 0
+    seccompProfile:
+      # -- The Seccomp profile to apply to this container.
+      type: RuntimeDefault
   # -- Optional security context for pods.
   podSecurityContext: {}
 


### PR DESCRIPTION
## Summary
This PR enforces some `securityContext` options to improve the security of the R2Devops application at runtime.

## Description
The enforced options ensure that :
- The containers are run without privileges and without permission to escalate their privileges
- Some unnecessary syscalls are blocked by the RuntimeDefault Seccomp profile
- All Linux special capabilities are blocked for R2 containers by the container runtime

**NB :** When I tried to run the front container as a non-root user (uid=65534),  encountered some issues related to custom CA certificates handling (didn't try with backend or worker containers), so I left uid=0 and gid=0 until the images evolve to support rootless mode.