### PR TITLE
conf(chart): only create custom CA ConfigMap if .certificates is set

### DIFF
--- a/charts/r2devops/Chart.yaml
+++ b/charts/r2devops/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: r2devops
 description: Helm chart for R2Devops
 type: application
-version: "2.14.1"
-appVersion: "2.14.1"
+version: "2.14.2"
+appVersion: "2.14.2"
 home: https://github.com/r2devops/self-managed/
 maintainers:
   - name: devpro

--- a/charts/r2devops/templates/configmap.yaml
+++ b/charts/r2devops/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.customCertificateAuthority.certificates }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -14,8 +15,9 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- end }}
-  name: {{ .Values.customCertificateAuthority.configMapName }}
+  name: {{ .Values.customCertificateAuthority.configMapName | default "r2devops-ca-certificates" }}
 data:
   {{- range .Values.customCertificateAuthority.certificates }}
   {{ .name }}: {{ .value | quote }}
   {{- end }}
+{{- end }}

--- a/charts/r2devops/templates/deployment.yaml
+++ b/charts/r2devops/templates/deployment.yaml
@@ -199,14 +199,19 @@ spec:
       {{- end }}
 
       volumes:
+        {{- with $.Values.customCertificateAuthority }}
         - name: ca-certificates
-          {{- if $.Values.customCertificateAuthority.existingSecret }}
+          {{- if .existingSecret }}
           secret:
-            secretName: {{ $.Values.customCertificateAuthority.existingSecret }}
-          {{- else }}
+            secretName: {{ .existingSecret }}
+          {{- else if or .configMapName .certificates }}
           configMap:
-            name: {{ $.Values.customCertificateAuthority.configMapName }}
+            name: {{ .configMapName | default "r2devops-ca-certificates" }}
+          {{- else }}
+          emptyDir:
+            sizeLimit: 1Ki
           {{- end }}
+        {{- end }}
 
         {{- if eq .type "backend" }}
           {{- if and $.Values.postgresql.global.postgresql.auth.existingSecret (eq (default "" $.Values.postgresql.global.postgresql.auth.existingSecretType) "csi") }}

--- a/charts/r2devops/tests/configmap_test.yaml
+++ b/charts/r2devops/tests/configmap_test.yaml
@@ -1,0 +1,58 @@
+---
+suite: Test custom CA certificates configmap
+templates:
+  - configmap.yaml
+release:
+  name: r2devops
+tests:
+  - it: ConfigMap should be absent if certificates is empty
+    set:
+      customCertificateAuthority:
+        configMapName: dummy-value
+        certificates:
+          - name: file
+            value: |
+              MY SUPER CERTIFICATE
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.file
+          value: |
+            MY SUPER CERTIFICATE
+
+  - it: ConfigMap name should be r2devops-ca-certificates if not provided
+    set:
+      customCertificateAuthority:
+        configMapName: ""
+        certificates:
+          - name: file
+            value: |
+              MY SUPER CERTIFICATE
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: r2devops-ca-certificates
+
+  - it: ConfigMap name should be customizable
+    set:
+      customCertificateAuthority:
+        configMapName: custom-configmap-name
+        certificates:
+          - name: file
+            value: |
+              MY SUPER CERTIFICATE
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: custom-configmap-name

--- a/charts/r2devops/tests/deployment_test.yaml
+++ b/charts/r2devops/tests/deployment_test.yaml
@@ -1,0 +1,95 @@
+---
+suite: Test custom CA certificates configmap
+templates:
+  - deployment.yaml
+release:
+  name: r2devops
+tests:
+  - it: Deployments should have an empty ca-certificates volume if not configured
+    set:
+      customCertificateAuthority:
+        configMapName: ""
+        certificates: []
+    asserts:
+      - hasDocuments:
+          count: 3
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certificates
+            emptyDir:
+              sizeLimit: 1Ki
+
+  - it: Deployments should bind to an external secret if .existingSecret is set
+    set:
+      customCertificateAuthority:
+        existingSecret: my-custom-secret
+    asserts:
+      - hasDocuments:
+          count: 3
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certificates
+            secret:
+              secretName: my-custom-secret
+
+  - it: Deployments should bind to a ConfigMap if .configMapName is set
+    set:
+      customCertificateAuthority:
+        configMapName: my-custom-configmap
+    asserts:
+      - hasDocuments:
+          count: 3
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certificates
+            configMap:
+              name: my-custom-configmap
+
+  - it: Deployments should bind to a ConfigMap if .configMapName and .certificates are set
+    set:
+      customCertificateAuthority:
+        configMapName: my-custom-configmap
+        certificates:
+          - name: file
+            value: |
+              MY SUPER CERTIFICATE
+    asserts:
+      - hasDocuments:
+          count: 3
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certificates
+            configMap:
+              name: my-custom-configmap
+
+  - it: Deployments should bind to a default ConfigMap name if .certificates is set but not .configMapName
+    set:
+      customCertificateAuthority:
+        configMapName: ""
+        certificates:
+          - name: file
+            value: |
+              MY SUPER CERTIFICATE
+    asserts:
+      - hasDocuments:
+          count: 3
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certificates
+            configMap:
+              name: r2devops-ca-certificates

--- a/charts/r2devops/values.yaml
+++ b/charts/r2devops/values.yaml
@@ -157,7 +157,7 @@ ingress:
 # Custom certificates
 customCertificateAuthority:
   existingSecret: ""
-  configMapName: "r2devops-ca-certificates"
+  configMapName: ""
   certificates: []
   # - name: rootCA.crt # Must have the .crt extension
   #   value: |


### PR DESCRIPTION
## Summary
This PR fixes the Helm chart behavior regarding custom CA certificates.

## Description
Currently, a ConfigMap containing the custom CA certificates is always created by the chart, overriding any existing one.
Thus, you cannot create a custom ConfigMap and bind it to R2 pods.

This PR fixes this bug by implementing the following behavior :
1. If `.Values.customCertificateAuthority.certificates` if empty (the default value), the ConfigMap is not created
2. If `.Values.customCertificateAuthority.certificates` is not empty, a ConfigMap is created using `.configMapName` as resource name
3. `.configMapName` has no default value anymore, but backward compatibility is ensured by `default` usage in the templates.
4. If `.certificates` and `.configMapName` are both empty, an emptyDir is used as ca-certificates volume.

This last point is not necessary, but avoids adding a complex condition around `volumes` property which would ensure that volumes are really needed. I chose this option assuming that an emptyDir would necessary be required when the container images will run rootless (to generate the complete ca-bundle in a writable directory).

**NB :**
- I added some helm unittest test suites to validate my implementation. I'll add a GH Action in another PR to automate these non-regression tests (see #297). This is cleary opinionated. Let me know if I should remove these tests.
- BREAKING CHANGE : if a user defines `configMapName` but no `certificates`, the chart will mount an existing ConfigMap with this name in all pods (before this change, the ConfigMap was created by the chart).